### PR TITLE
Add known-working Dockerfile including ruby/jekyll/submodule installation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:24.04
+
+RUN apt update && apt install -y build-essential git ruby-full zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /docs && chown ubuntu:ubuntu /docs
+
+WORKDIR /docs
+
+USER ubuntu
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
+ENV GEM_HOME=/home/ubuntu/gems
+ENV PATH=$PATH:/home/ubuntu/gems/bin
+ENV JEKYLL_ENV=production
+
+RUN gem install jekyll bundler
+
+COPY --chown=ubuntu:ubuntu Gemfile .
+
+RUN bundle install
+
+COPY --chown=ubuntu:ubuntu . .
+
+RUN git config --global --add safe.directory /docs
+
+RUN git submodule update --init
+
+CMD ["bundle", "exec", "jekyll", "serve", "--config", "_config.yml", "--host", "0", "--baseurl", ""]

--- a/README.md
+++ b/README.md
@@ -33,3 +33,19 @@ Then build the site again.
 bundle exec jekyll serve --config _config.yml --watch --verbose --incremental
 ```
 And review at http://127.0.0.1:4000/mbon-docs/
+
+## Deploying/testing locally using Docker
+
+After cloning the repository, build the Docker image in the project directory:
+
+```
+docker build -t ioos-mbon-docs .
+```
+
+and run the docs site, adjusting the port if needed:
+
+```
+docker run --rm -p 4000:4000 mbon-docs
+```
+
+Review at http://localhost:4000/


### PR DESCRIPTION
@ocefpaf @MathewBiddle @mwengren Any thoughts? I struggled with getting a working local environment for a while due to ruby/glibc issues. Nice to have a portable Dockerfile spelling out the needed dependencies, env vars, etc.