### PR TITLE
Use dependabot to update pre-commits and fix zizmor lints

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,14 @@ updates:
       github-actions:
         patterns:
           - '*'
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "Bot"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/sync_theme.yml
+++ b/.github/workflows/sync_theme.yml
@@ -1,5 +1,8 @@
 name: sync theme submodules
 
+# no permissions by default
+permissions: {}
+
 on:
   push:
     branches: gh-pages
@@ -9,14 +12,19 @@ on:
 
   workflow_dispatch:
 
-
 jobs:
   sync_theme_submodules:
     if: github.repository_owner == 'ioos' # only run if ioos owns repo
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - name: Checkout repo
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: gh-pages
+        fetch-depth: 0
+        persist-credentials: false
 
     - name: submodule checkout
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+- repo: https://github.com/woodruffw/zizmor-pre-commit
+  rev: v1.25.2
+  hooks:
+    - id: zizmor
+
+ci:
+    autofix_commit_msg: |
+        [pre-commit.ci] auto fixes from pre-commit.com hooks
+
+        for more information, see https://pre-commit.ci
+    autofix_prs: false
+    skip: []
+    submodules: false


### PR DESCRIPTION
Implement zizmor checks, fix GHA, and add pre-commit updates via dependabot.